### PR TITLE
Typecast variable to int to avoid error in PHP 7+

### DIFF
--- a/library/LarkSpark/ArtNet/ArtDmxClient.php
+++ b/library/LarkSpark/ArtNet/ArtDmxClient.php
@@ -79,7 +79,7 @@ class ArtDmxClient
 
         // apply dmx values to payload
         foreach ($dmx as $x => $value) {
-            $payload[$x] = chr($value);
+            $payload[$x] = chr((int)$value);
         }
 
         // calculate low and high byte for DMX bytes


### PR DESCRIPTION
Error: Passing null to parameter #1 ($codepoint) of type int is deprecated in ArtDmxClient.php on line 82. To avoid passing null to `chr()` we can typecast it to an (int) first.